### PR TITLE
Fix iverilog git url

### DIFF
--- a/iverilog.sh
+++ b/iverilog.sh
@@ -8,7 +8,7 @@ UNAME_STR=`uname`
 
 if [ ! -d $DIR/iverilog ]; then
 	echo "Checking out iverilog..."
-	git clone git://github.com/steveicarus/iverilog.git $DIR/iverilog
+	git clone git@github.com:steveicarus/iverilog.git $DIR/iverilog
 else
 	cd $DIR/iverilog
 	echo "Updating iverilog..."


### PR DESCRIPTION
```
fatal: remote error: 
  The unauthenticated git protocol on port 9418 is no longer supported.
```
Please see https://github.blog/2021-09-01-improving-git-protocol-security-github/ for more information.
